### PR TITLE
Upgrade versions of fedora and drawio-desktop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM fedora:latest
+FROM fedora:42
 WORKDIR /code
 RUN dnf install -y python3-pip xorg-x11-server-Xvfb alsa-lib make findutils gdouros-symbola-fonts google-noto-emoji-fonts google-noto-emoji-color-fonts \
     && dnf group install -y fonts \
-    && dnf install -y https://github.com/jgraph/drawio-desktop/releases/download/v19.0.3/drawio-x86_64-19.0.3.rpm \
+    && dnf install -y awk https://github.com/jgraph/drawio-desktop/releases/download/v27.0.9/drawio-x86_64-27.0.9.rpm \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 COPY requirements.txt server.py openapi.yaml ./

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,11 @@
 # Python PIP Package Requirements
 # Run 'pip install -r requirements.txt'
 
-Flask
-flask-expects-json
-flask-redoc
-gunicorn
+# required by Flask, this exact version works
+werkzeug==2.1.2
+
+# requirements
+Flask==2.1.2
+flask-expects-json==1.7.0
+flask-redoc==0.2.1
+gunicorn==20.1.0


### PR DESCRIPTION
Hi @tomkludy ,

please, review the changes in order to upgrade version of DrawIO-Desktop used in your gorgeous project.
Started with just changing RPM download URL, I faced issues with incompatibility the actual versions of Python dependencies.
Because that they were defined with exact versions, taken from the latest Docker image.

The changes were successfully tested with documentation diagrams in [PzdcDoc](https://pzdcdoc.org) and [BGERP](https://bgerp.org) projects.

Liebe Grüße,
Shamil.